### PR TITLE
Fix silently-swallowed exceptions in api_client.py and bot_handlers.py

### DIFF
--- a/src/api_client.py
+++ b/src/api_client.py
@@ -31,9 +31,11 @@ class APIClient:
         try:
             return res.json()
         except Exception:
+            logger.exception("Failed to parse JSON response from %s", res.url)
             try:
                 return {"detail": res.text}
             except Exception:
+                logger.exception("Failed to read response text from %s", res.url)
                 return {"detail": "Invalid response from server"}
 
     async def _request(self, method: str, path: str, json: Optional[dict] = None) -> Tuple[int, dict]:
@@ -115,4 +117,4 @@ class APIClient:
         try:
             await self._client.aclose()
         except Exception:
-            pass
+            logger.exception("Failed to close the HTTP client cleanly")

--- a/src/bot_handlers.py
+++ b/src/bot_handlers.py
@@ -281,17 +281,17 @@ class BotHandlers:
                 try:
                     await query.answer(f"Request {action}d", show_alert=False)
                 except Exception:
-                    pass
+                    self.logger.exception("Failed to answer callback query for request %s", request_id)
             elif status_code == 403:
                 try:
                     await query.answer("You are not authorized to do that.", show_alert=True)
                 except Exception:
-                    pass
+                    self.logger.exception("Failed to answer callback query for request %s", request_id)
             elif status_code == 404:
                 try:
                     await query.answer("Recharge request not found.", show_alert=True)
                 except Exception:
-                    pass
+                    self.logger.exception("Failed to answer callback query for request %s", request_id)
             elif status_code == 409:
                 detail = res.get("detail", "Request already resolved.")
                 resolved_by = res.get("resolved_by_username")
@@ -300,12 +300,12 @@ class BotHandlers:
                 try:
                     await query.answer(detail, show_alert=True)
                 except Exception:
-                    pass
+                    self.logger.exception("Failed to answer callback query for request %s", request_id)
             else:
                 try:
                     await query.answer(res.get("detail", "Unknown error"), show_alert=True)
                 except Exception:
-                    pass
+                    self.logger.exception("Failed to answer callback query for request %s", request_id)
             return
 
         if msg is not None:

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,50 @@
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.api_client import APIClient
+
+
+def make_client():
+    return APIClient(base_url="http://example.test", secret="secret")
+
+
+def test_safe_json_logs_on_parse_failure(caplog):
+    client = make_client()
+    res = MagicMock()
+    res.json.side_effect = ValueError("not json")
+    res.text = "plain text body"
+    res.url = "http://example.test/x"
+
+    with caplog.at_level(logging.ERROR):
+        result = client._safe_json(res)
+
+    assert result == {"detail": "plain text body"}
+    assert "Failed to parse JSON response" in caplog.text
+
+
+def test_safe_json_logs_on_text_failure_too(caplog):
+    client = make_client()
+    res = MagicMock()
+    res.json.side_effect = ValueError("not json")
+    type(res).text = property(lambda self: (_ for _ in ()).throw(RuntimeError("no text either")))
+    res.url = "http://example.test/x"
+
+    with caplog.at_level(logging.ERROR):
+        result = client._safe_json(res)
+
+    assert result == {"detail": "Invalid response from server"}
+    assert "Failed to parse JSON response" in caplog.text
+    assert "Failed to read response text" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_close_logs_when_aclose_fails(caplog):
+    client = make_client()
+    client._client.aclose = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with caplog.at_level(logging.ERROR):
+        await client.close()
+
+    assert "Failed to close the HTTP client cleanly" in caplog.text

--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -1,0 +1,31 @@
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.bot_handlers import BotHandlers
+from src.services import UserService
+from tests.conftest import FakeAPIClient
+
+
+def make_query(data, answer_side_effect=None):
+    answer = AsyncMock(side_effect=answer_side_effect)
+    message = SimpleNamespace(chat=SimpleNamespace(id=123), reply_text=AsyncMock())
+    return SimpleNamespace(data=data, message=message, answer=answer)
+
+
+@pytest.mark.asyncio
+async def test_button_callback_logs_when_answer_fails(caplog):
+    fake_client = FakeAPIClient(response=(200, {}))
+    handlers = BotHandlers(services={"user": UserService(fake_client)})
+
+    query = make_query("rr:approve:req123", answer_side_effect=RuntimeError("telegram unavailable"))
+    update = SimpleNamespace(callback_query=query)
+    context = SimpleNamespace(bot=AsyncMock())
+
+    with caplog.at_level(logging.ERROR):
+        await handlers.button_callback(update, context)
+
+    query.answer.assert_awaited_once()
+    assert "Failed to answer callback query for request req123" in caplog.text


### PR DESCRIPTION
## Summary
Inventory of every broad `except Exception` block in `src/` found 23 total; 15 already logged correctly. The remaining 8 silently swallowed errors:
- `api_client.py:_safe_json` — both fallback branches (JSON parse failure, then text-read failure)
- `api_client.py:close()` — `aclose()` failure
- `bot_handlers.py:button_callback` — all 5 `query.answer(...)` except branches

All 8 now log via `logger.exception`/`self.logger.exception`, consistent with the pattern already used elsewhere in the same files/classes. No behavior change otherwise — these are all best-effort side paths (a failed callback-query ack, a failed client shutdown) that shouldn't crash the caller, just no longer silently vanish.

## Test plan
- [x] `pytest -q` — 13 passed (9 existing + 4 new)
- [x] `flake8` clean on touched files
- New tests: `test_api_client.py` (both `_safe_json` branches + `close()` log correctly), `test_bot_handlers.py` (`button_callback` logs when `query.answer()` raises)