### PR TITLE
Interactive Telegram flows for stock, expenses, recharges, and balance adjustments

### DIFF
--- a/src/api_client.py
+++ b/src/api_client.py
@@ -113,6 +113,21 @@ class APIClient:
         payload = {"chat_id": str(chat_id), "action": action}
         return await self._patch(f"/telegram/recharge-requests/{request_id}", json=payload)
 
+    async def resolve_product_purchase(self, chat_id: int, purchase_id: str, action: str):
+        payload = {"chat_id": str(chat_id), "action": action}
+        return await self._patch(f"/telegram/product-purchases/{purchase_id}", json=payload)
+
+    async def get_inventory(self, chat_id: int):
+        return await self._get("/telegram/inventory", json={"chat_id": str(chat_id)})
+
+    async def adjust_stock(self, chat_id: int, item_name: str, delta: float):
+        payload = {"chat_id": str(chat_id), "item_name": item_name, "delta": delta}
+        return await self._patch("/telegram/stock-adjust", json=payload)
+
+    async def create_expense(self, chat_id: int, category: str, amount: float, description: str | None = None):
+        payload = {"chat_id": str(chat_id), "category": category, "amount": amount, "description": description}
+        return await self._post("/telegram/expenses", json=payload)
+
     async def close(self):
         try:
             await self._client.aclose()

--- a/src/bot_app.py
+++ b/src/bot_app.py
@@ -3,12 +3,31 @@ import asyncio
 import logging
 
 from telegram import BotCommand
-from telegram.ext import Application, CommandHandler, CallbackQueryHandler
+from telegram.ext import (
+    Application,
+    CommandHandler,
+    CallbackQueryHandler,
+    ConversationHandler,
+    MessageHandler,
+    filters,
+)
 
 from .config import get_config
 from .logger import get_logger
 from .services import create_services
-from .bot_handlers import BotHandlers
+from .bot_handlers import (
+    BotHandlers,
+    STOCK_CHOOSE_ITEM,
+    STOCK_ADJUST_DELTA,
+    EXPENSE_CHOOSE_CATEGORY,
+    EXPENSE_AWAIT_AMOUNT,
+    EXPENSE_AWAIT_DESCRIPTION,
+    EXPENSE_CONFIRM,
+    RECHARGE_SEARCH,
+    RECHARGE_AWAIT_AMOUNT,
+    ADJUST_SEARCH,
+    ADJUST_AWAIT_AMOUNT,
+)
 
 
 class BotApp:
@@ -67,10 +86,100 @@ class BotApp:
         self._app.add_handler(CommandHandler("myid", handlers.myid))
         self._app.add_handler(CommandHandler("users", handlers.list_users))
         self._app.add_handler(CommandHandler("user", handlers.get_user_info))
-        self._app.add_handler(CommandHandler("recharge", handlers.recharge))
-        self._app.add_handler(CommandHandler("adjust", handlers.adjust))
         self._app.add_handler(CommandHandler("request_recharge", handlers.request_recharge))
-        self._app.add_handler(CallbackQueryHandler(handlers.button_callback))
+
+        # Guided, button-driven flows — one-shot command args still work as
+        # a fallback (see each entry point), but the default path is
+        # buttons + prompts rather than memorized command syntax.
+        stock_conv = ConversationHandler(
+            entry_points=[CommandHandler("stock", handlers.stock_entry)],
+            states={
+                STOCK_CHOOSE_ITEM: [
+                    CallbackQueryHandler(handlers.stock_choose_item, pattern="^stock:item:"),
+                    CallbackQueryHandler(handlers.stock_cancel, pattern="^stock:cancel$"),
+                ],
+                STOCK_ADJUST_DELTA: [
+                    CallbackQueryHandler(handlers.stock_step, pattern="^stock:step:"),
+                    CallbackQueryHandler(handlers.stock_confirm, pattern="^stock:confirm$"),
+                    CallbackQueryHandler(handlers.stock_cancel, pattern="^stock:cancel$"),
+                ],
+            },
+            fallbacks=[
+                CallbackQueryHandler(handlers.stock_cancel, pattern="^stock:cancel$"),
+                CommandHandler("cancel", handlers.cancel_command),
+            ],
+            conversation_timeout=300,
+        )
+        expense_conv = ConversationHandler(
+            entry_points=[CommandHandler("expense", handlers.expense_entry)],
+            states={
+                EXPENSE_CHOOSE_CATEGORY: [
+                    CallbackQueryHandler(handlers.expense_choose_category, pattern="^expense:cat:"),
+                    CallbackQueryHandler(handlers.expense_cancel, pattern="^expense:cancel$"),
+                ],
+                EXPENSE_AWAIT_AMOUNT: [
+                    MessageHandler(filters.TEXT & ~filters.COMMAND, handlers.expense_receive_amount),
+                ],
+                EXPENSE_AWAIT_DESCRIPTION: [
+                    CallbackQueryHandler(handlers.expense_skip_description, pattern="^expense:skip_desc$"),
+                    MessageHandler(filters.TEXT & ~filters.COMMAND, handlers.expense_receive_description),
+                ],
+                EXPENSE_CONFIRM: [
+                    CallbackQueryHandler(handlers.expense_confirm, pattern="^expense:confirm$"),
+                    CallbackQueryHandler(handlers.expense_cancel, pattern="^expense:cancel$"),
+                ],
+            },
+            fallbacks=[
+                CallbackQueryHandler(handlers.expense_cancel, pattern="^expense:cancel$"),
+                CommandHandler("cancel", handlers.cancel_command),
+            ],
+            conversation_timeout=300,
+        )
+        recharge_conv = ConversationHandler(
+            entry_points=[CommandHandler("recharge", handlers.recharge_entry)],
+            states={
+                RECHARGE_SEARCH: [
+                    CallbackQueryHandler(handlers.recharge_choose_user, pattern="^recharge:user:"),
+                    CallbackQueryHandler(handlers.recharge_cancel, pattern="^recharge:cancel$"),
+                    MessageHandler(filters.TEXT & ~filters.COMMAND, handlers.recharge_search),
+                ],
+                RECHARGE_AWAIT_AMOUNT: [
+                    MessageHandler(filters.TEXT & ~filters.COMMAND, handlers.recharge_receive_amount),
+                ],
+            },
+            fallbacks=[
+                CallbackQueryHandler(handlers.recharge_cancel, pattern="^recharge:cancel$"),
+                CommandHandler("cancel", handlers.cancel_command),
+            ],
+            conversation_timeout=300,
+        )
+        adjust_conv = ConversationHandler(
+            entry_points=[CommandHandler("adjust", handlers.adjust_entry)],
+            states={
+                ADJUST_SEARCH: [
+                    CallbackQueryHandler(handlers.adjust_choose_user, pattern="^adjust:user:"),
+                    CallbackQueryHandler(handlers.adjust_cancel, pattern="^adjust:cancel$"),
+                    MessageHandler(filters.TEXT & ~filters.COMMAND, handlers.adjust_search),
+                ],
+                ADJUST_AWAIT_AMOUNT: [
+                    MessageHandler(filters.TEXT & ~filters.COMMAND, handlers.adjust_receive_amount),
+                ],
+            },
+            fallbacks=[
+                CallbackQueryHandler(handlers.adjust_cancel, pattern="^adjust:cancel$"),
+                CommandHandler("cancel", handlers.cancel_command),
+            ],
+            conversation_timeout=300,
+        )
+
+        self._app.add_handler(stock_conv)
+        self._app.add_handler(expense_conv)
+        self._app.add_handler(recharge_conv)
+        self._app.add_handler(adjust_conv)
+
+        # Restricted to the prefixes it actually handles now that stock:/
+        # expense: callbacks are routed by the ConversationHandlers above.
+        self._app.add_handler(CallbackQueryHandler(handlers.button_callback, pattern="^(rr|pp):"))
 
         # Global error handler: handle timeouts specially and log unexpected errors
         async def _global_error_handler(update, context):

--- a/src/bot_handlers.py
+++ b/src/bot_handlers.py
@@ -1,12 +1,27 @@
 from html import escape
 
 from telegram import BotCommand, BotCommandScopeChat, InlineKeyboardMarkup, InlineKeyboardButton
-from telegram.ext import ContextTypes
+from telegram.ext import ContextTypes, ConversationHandler
 
-from .services import create_services
+from .services import create_services, validate_expense_input, EXPENSE_CATEGORIES
 from .logger import LOGGER_MANAGER
 from .config import get_config
 from .utilities import safe_handler
+
+
+# Conversation states — two independent ConversationHandlers (wired in
+# bot_app.py), so overlapping int values across them are harmless.
+STOCK_CHOOSE_ITEM, STOCK_ADJUST_DELTA = range(2)
+EXPENSE_CHOOSE_CATEGORY, EXPENSE_AWAIT_AMOUNT, EXPENSE_AWAIT_DESCRIPTION, EXPENSE_CONFIRM = range(4)
+RECHARGE_SEARCH, RECHARGE_AWAIT_AMOUNT = range(2)
+ADJUST_SEARCH, ADJUST_AWAIT_AMOUNT = range(2)
+
+EXPENSE_CATEGORY_LABELS = {
+    "toner": "🖨️ Toner",
+    "paper": "📄 Paper",
+    "maintenance": "🔧 Maintenance",
+    "other": "📦 Other",
+}
 
 
 class BotHandlers:
@@ -23,9 +38,11 @@ class BotHandlers:
             BotCommand("myid", "Show your Telegram chat ID"),
             BotCommand("users", "List all users"),
             BotCommand("user", "Get user info by username"),
-            BotCommand("recharge", "Recharge a user's balance"),
-            BotCommand("adjust", "Adjust a user's balance"),
+            BotCommand("recharge", "Search a user, then recharge their balance"),
+            BotCommand("adjust", "Search a user, then set their balance"),
             BotCommand("request_recharge", "Request a balance recharge"),
+            BotCommand("stock", "View or adjust inventory stock"),
+            BotCommand("expense", "Log an expense (guided, asks to confirm)"),
         ]
 
     def _user_commands(self) -> list[BotCommand]:
@@ -179,6 +196,48 @@ class BotHandlers:
                     notification["chat_id"],
                 )
 
+    def _build_purchase_resolution_text(self, payload: dict) -> str:
+        purchase = payload.get("purchase", {})
+        status = purchase.get("status")
+        resolved_by = purchase.get("resolved_by_username") or "unknown admin"
+        if status == "fulfilled":
+            header = "✅ <b>Purchase Given</b>"
+        else:
+            header = "❌ <b>Purchase Rejected & Refunded</b>"
+
+        lines = [
+            header,
+            "",
+            f"👤 <b>User:</b> {self._escape_html(purchase.get('username'))}",
+            f"📦 <b>Item:</b> {purchase.get('quantity')}x {self._escape_html(purchase.get('product_name'))}",
+            f"💶 <b>Total:</b> {float(purchase.get('total_amount', 0)):.2f}€",
+            f"🛠️ <b>Handled by:</b> {self._escape_html(resolved_by)}",
+        ]
+        if purchase.get("admin_message"):
+            lines.append(f"📝 <b>Note:</b> {self._escape_html(purchase['admin_message'])}")
+        return "\n".join(lines)
+
+    async def _edit_purchase_notifications(self, context: ContextTypes.DEFAULT_TYPE, payload: dict):
+        """Every admin was notified individually about this purchase (it's
+        broadcast to all of them, unlike a recharge request's single
+        target admin), so resolving it has to edit every one of those
+        messages, not just one."""
+        text = self._build_purchase_resolution_text(payload)
+        for notification in payload.get("notifications", []):
+            try:
+                await context.bot.edit_message_text(
+                    chat_id=int(notification["chat_id"]),
+                    message_id=notification["message_id"],
+                    text=text,
+                    parse_mode="HTML",
+                )
+            except Exception:
+                self.logger.exception(
+                    "Failed to update admin notification for purchase %s in chat_id=%s",
+                    payload.get("purchase", {}).get("id"),
+                    notification.get("chat_id"),
+                )
+
     async def _notify_requester_of_resolution(self, context: ContextTypes.DEFAULT_TYPE, payload: dict):
         request = payload.get("request", {})
         status = request.get("status")
@@ -224,11 +283,17 @@ class BotHandlers:
                 "/user &lt;username&gt; – Show user info\n\n"
 
                 "💳 <b>Balance</b>\n"
-                "/recharge &lt;username&gt; &lt;amount&gt; – Add credit to a user\n"
-                "/adjust &lt;username&gt; &lt;new_balance&gt; – Set a user balance manually\n\n"
+                "/recharge – Search for a user, then enter an amount to add\n"
+                "/adjust – Search for a user, then set their balance directly\n\n"
 
                 "📩 <b>Recharge Requests</b>\n"
-                "Users can send recharge requests here, and you can approve or reject them directly from the bot."
+                "Users can send recharge requests here, and you can approve or reject them directly from the bot.\n\n"
+
+                "📦 <b>Inventory</b>\n"
+                "/stock – Pick an item, then use the +/- buttons and Confirm\n\n"
+
+                "🧾 <b>Expenses</b>\n"
+                "/expense – Pick a category, enter the amount, then confirm before it's logged"
             )
 
         elif status_code == 403:
@@ -319,6 +384,49 @@ class BotHandlers:
                     await query.answer(res.get("detail", "Unknown error"), show_alert=True)
                 except Exception:
                     self.logger.exception("Failed to answer callback query for request %s", request_id)
+            return
+
+        if data and data.startswith("pp:"):
+            parts = data.split(":", 2)
+            if len(parts) != 3:
+                if msg is not None:
+                    await msg.reply_text("❌ Invalid purchase action.")
+                return
+
+            action = parts[1]
+            purchase_id = parts[2]
+            status_code, res = await self.user_service.resolve_product_purchase(chat_id, purchase_id, action)
+
+            if status_code == 200:
+                await self._edit_purchase_notifications(context, res)
+                try:
+                    await query.answer(f"Purchase {action}ed" if action == "reject" else "Marked as given", show_alert=False)
+                except Exception:
+                    self.logger.exception("Failed to answer callback query for purchase %s", purchase_id)
+            elif status_code == 403:
+                try:
+                    await query.answer("You are not authorized to do that.", show_alert=True)
+                except Exception:
+                    self.logger.exception("Failed to answer callback query for purchase %s", purchase_id)
+            elif status_code == 404:
+                try:
+                    await query.answer("Purchase not found.", show_alert=True)
+                except Exception:
+                    self.logger.exception("Failed to answer callback query for purchase %s", purchase_id)
+            elif status_code == 409:
+                detail = res.get("detail", "Purchase already resolved.")
+                resolved_by = res.get("resolved_by_username")
+                if resolved_by:
+                    detail = f"{detail} By {resolved_by}."
+                try:
+                    await query.answer(detail, show_alert=True)
+                except Exception:
+                    self.logger.exception("Failed to answer callback query for purchase %s", purchase_id)
+            else:
+                try:
+                    await query.answer(res.get("detail", "Unknown error"), show_alert=True)
+                except Exception:
+                    self.logger.exception("Failed to answer callback query for purchase %s", purchase_id)
             return
 
         if msg is not None:
@@ -425,54 +533,722 @@ class BotHandlers:
         else:
             await update.message.reply_text(f"⚠️ Error: {res.get('detail', 'Unknown error')}")
 
-    @safe_handler
-    async def recharge(self, update, context: ContextTypes.DEFAULT_TYPE):
-        chat = getattr(update, "effective_chat", None)
-        chat_id = getattr(chat, "id", None)
-        args = getattr(context, "args", None) or []
-        if len(args) != 2:
-            message = getattr(update, "message", None)
-            if message is not None:
-                await message.reply_text("Usage: /recharge <username> <amount>")
-            return
+    # ---- /recharge and /adjust: guided user search + picker, one-shot args as fallback ----
 
-        username = args[0]
-        status_code, res = await self.user_service.recharge(chat_id, username, args[1])
+    # Buttons only render when a search narrows the result to this many or
+    # fewer — with 60+ users, showing every one of them as a button would
+    # be unusable, so a big/unfiltered list gets a text prompt instead.
+    USER_PICKER_THRESHOLD = 10
+    MIN_USER_SEARCH_CHARS = 2
 
+    def _format_user_label(self, user: dict) -> str:
+        name = f"{user.get('name', '')} {user.get('surname', '')}".strip()
+        username = user.get("username")
+        return f"{name} (@{username})" if name else f"@{username}"
+
+    def _filter_users(self, users: list[dict], query: str) -> list[dict]:
+        q = query.strip().lower()
+        if not q:
+            return users
+        return [
+            u for u in users
+            if q in f"{u.get('username', '')} {u.get('name', '')} {u.get('surname', '')}".lower()
+        ]
+
+    def _build_user_picker_buttons(self, users: list[dict], prefix: str) -> InlineKeyboardMarkup:
+        buttons = [
+            [InlineKeyboardButton(self._format_user_label(u), callback_data=f"{prefix}:user:{u.get('username')}")]
+            for u in users
+        ]
+        buttons.append([InlineKeyboardButton("❌ Cancel", callback_data=f"{prefix}:cancel")])
+        return InlineKeyboardMarkup(buttons)
+
+    def _amount_prompt_text(self, prefix: str, user: dict) -> str:
+        if prefix == "recharge":
+            return f"Selected @{user.get('username')}. How much to recharge? (e.g. 10)"
+        return (
+            f"Selected @{user.get('username')} (current balance {float(user.get('balance', 0)):.2f}€). "
+            "Set balance to how much? (e.g. 0)"
+        )
+
+    def _format_recharge_result(self, username: str, amount, status_code: int, res: dict) -> str:
         if status_code == 200:
-            message = getattr(update, "message", None)
-            if message is not None:
-                await message.reply_text(f"💰 Successfully recharged {username} with {float(args[1]):.2f}€")
+            return f"💰 Successfully recharged {username} with {float(amount):.2f}€"
         elif status_code == 403:
-            await update.message.reply_text("❌ You are not authorized to recharge users.")
+            return "❌ You are not authorized to recharge users."
         elif status_code == 404:
-            await update.message.reply_text("⚠️ User not found.")
+            return "⚠️ User not found."
+        elif status_code == 400:
+            return f"❌ {res.get('detail', 'Invalid amount')}"
         else:
-            await update.message.reply_text(f"⚠️ Error: {res.get('detail', 'Unknown error')}")
+            return f"⚠️ Error: {res.get('detail', 'Unknown error')}"
 
-    @safe_handler
-    async def adjust(self, update, context: ContextTypes.DEFAULT_TYPE):
-        chat = getattr(update, "effective_chat", None)
-        chat_id = getattr(chat, "id", None)
-        args = getattr(context, "args", None) or []
-        if len(args) != 2:
-            message = getattr(update, "message", None)
-            if message is not None:
-                await message.reply_text("Usage: /adjust <username> <new_balance>")
-            return
-
-        username = args[0]
-        status_code, res = await self.user_service.adjust(chat_id, username, args[1])
-
+    def _format_adjust_result(self, username: str, status_code: int, res: dict) -> str:
         if status_code == 200:
             name = res.get("name") or username
             balance = res.get("balance")
-            await update.message.reply_text(f"🧾 Adjusted {name}'s balance to {balance:.2f}€")
+            return f"🧾 Adjusted {name}'s balance to {balance:.2f}€"
         elif status_code == 403:
-            await update.message.reply_text("❌ You are not authorized to adjust balances.")
+            return "❌ You are not authorized to adjust balances."
         elif status_code == 404:
-            await update.message.reply_text("⚠️ User not found.")
+            return "⚠️ User not found."
+        elif status_code == 400:
+            return f"❌ {res.get('detail', 'Invalid amount')}"
+        else:
+            return f"⚠️ Error: {res.get('detail', 'Unknown error')}"
+
+    async def _start_user_search(self, update, context: ContextTypes.DEFAULT_TYPE, prefix: str):
+        """Shared by /recharge and /adjust's no-args entry: fetch the user
+        list once and cache it in chat_data. Only renders it as tappable
+        buttons if it's small enough to browse — otherwise, it just asks
+        for a search term up front (see _handle_user_search_text)."""
+        chat = getattr(update, "effective_chat", None)
+        chat_id = getattr(chat, "id", None)
+        message = getattr(update, "message", None)
+
+        status_code, res = await self.user_service.list_users(chat_id)
+        if status_code == 403:
+            action = "recharge" if prefix == "recharge" else "adjust balances for"
+            if message is not None:
+                await message.reply_text(f"❌ You are not authorized to {action} users.")
+            return ConversationHandler.END
+        if status_code != 200:
+            if message is not None:
+                await message.reply_text(f"⚠️ Error: {res.get('detail', 'Unknown error')}")
+            return ConversationHandler.END
+        if not res:
+            if message is not None:
+                await message.reply_text("No users found.")
+            return ConversationHandler.END
+
+        context.chat_data[f"{prefix}_all_users"] = res
+        next_state = RECHARGE_SEARCH if prefix == "recharge" else ADJUST_SEARCH
+
+        if message is not None:
+            if len(res) <= self.USER_PICKER_THRESHOLD:
+                await message.reply_text(
+                    "👥 Tap a user, or type a name to search.",
+                    reply_markup=self._build_user_picker_buttons(res, prefix),
+                )
+            else:
+                await message.reply_text(
+                    f"👥 {len(res)} users total. Type at least {self.MIN_USER_SEARCH_CHARS} "
+                    "characters of a name or username to search."
+                )
+        return next_state
+
+    async def _prompt_for_amount(self, update, context: ContextTypes.DEFAULT_TYPE, user: dict, prefix: str, prompt_text: str, next_state, *, edit: bool):
+        context.chat_data[f"{prefix}_target"] = user
+        if edit:
+            query = getattr(update, "callback_query", None)
+            msg = getattr(query, "message", None) if query is not None else None
+            if msg is not None:
+                await msg.edit_text(prompt_text)
         else:
             message = getattr(update, "message", None)
             if message is not None:
+                await message.reply_text(prompt_text)
+        return next_state
+
+    async def _handle_user_search_text(self, update, context: ContextTypes.DEFAULT_TYPE, prefix: str, search_state, amount_state):
+        """Shared free-text step for both /recharge and /adjust: filters
+        the cached user list by whatever was typed, then either auto-picks
+        a single match, shows a small picker, or asks to narrow further."""
+        message = getattr(update, "message", None)
+        text = getattr(message, "text", "") if message is not None else ""
+        query = text.strip()
+        all_users = context.chat_data.get(f"{prefix}_all_users") or []
+
+        if len(query) < self.MIN_USER_SEARCH_CHARS:
+            if message is not None:
+                await message.reply_text(f"Type at least {self.MIN_USER_SEARCH_CHARS} characters to search.")
+            return search_state
+
+        matches = self._filter_users(all_users, query)
+
+        if not matches:
+            if message is not None:
+                await message.reply_text("No matching user. Try another name, or /cancel.")
+            return search_state
+
+        if len(matches) == 1:
+            user = matches[0]
+            prompt = self._amount_prompt_text(prefix, user)
+            return await self._prompt_for_amount(update, context, user, prefix, prompt, amount_state, edit=False)
+
+        if len(matches) > self.USER_PICKER_THRESHOLD:
+            if message is not None:
+                await message.reply_text(f"👥 {len(matches)} users match — type more of the name to narrow it down.")
+            return search_state
+
+        if message is not None:
+            await message.reply_text(
+                f"👥 {len(matches)} matches — tap one, or refine your search.",
+                reply_markup=self._build_user_picker_buttons(matches, prefix),
+            )
+        return search_state
+
+    async def _handle_user_choice_callback(self, update, context: ContextTypes.DEFAULT_TYPE, prefix: str, amount_state):
+        """Shared callback for both /recharge's and /adjust's user-picker buttons."""
+        query = getattr(update, "callback_query", None)
+        if query is None:
+            return ConversationHandler.END
+        data = getattr(query, "data", None) or ""
+        username = data.split(":", 2)[-1]
+        all_users = context.chat_data.get(f"{prefix}_all_users") or []
+        user = next((u for u in all_users if u.get("username") == username), None)
+
+        await query.answer()
+        if user is None:
+            msg = getattr(query, "message", None)
+            if msg is not None:
+                await msg.edit_text(f"⚠️ That user is no longer available. Run /{prefix} again.")
+            return ConversationHandler.END
+
+        prompt = self._amount_prompt_text(prefix, user)
+        return await self._prompt_for_amount(update, context, user, prefix, prompt, amount_state, edit=True)
+
+    async def _cancel_user_flow(self, update, context: ContextTypes.DEFAULT_TYPE, prefix: str):
+        query = getattr(update, "callback_query", None)
+        context.chat_data.pop(f"{prefix}_target", None)
+        context.chat_data.pop(f"{prefix}_all_users", None)
+        if query is not None:
+            await query.answer("Cancelled")
+            msg = getattr(query, "message", None)
+            if msg is not None:
+                await msg.edit_text("❌ Cancelled.")
+        return ConversationHandler.END
+
+    @safe_handler
+    async def recharge_entry(self, update, context: ContextTypes.DEFAULT_TYPE):
+        chat = getattr(update, "effective_chat", None)
+        chat_id = getattr(chat, "id", None)
+        args = getattr(context, "args", None) or []
+        message = getattr(update, "message", None)
+
+        if len(args) == 2:
+            # Fallback one-shot form: /recharge <username> <amount>
+            username = args[0]
+            status_code, res = await self.user_service.recharge(chat_id, username, args[1])
+            if message is not None:
+                await message.reply_text(self._format_recharge_result(username, args[1], status_code, res))
+            return ConversationHandler.END
+
+        return await self._start_user_search(update, context, "recharge")
+
+    @safe_handler
+    async def recharge_search(self, update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._handle_user_search_text(update, context, "recharge", RECHARGE_SEARCH, RECHARGE_AWAIT_AMOUNT)
+
+    @safe_handler
+    async def recharge_choose_user(self, update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._handle_user_choice_callback(update, context, "recharge", RECHARGE_AWAIT_AMOUNT)
+
+    @safe_handler
+    async def recharge_receive_amount(self, update, context: ContextTypes.DEFAULT_TYPE):
+        chat = getattr(update, "effective_chat", None)
+        chat_id = getattr(chat, "id", None)
+        message = getattr(update, "message", None)
+        text = getattr(message, "text", "") if message is not None else ""
+
+        user = context.chat_data.get("recharge_target")
+        if user is None:
+            if message is not None:
+                await message.reply_text("⚠️ Session expired. Run /recharge again.")
+            return ConversationHandler.END
+
+        username = user.get("username")
+        status_code, res = await self.user_service.recharge(chat_id, username, text.strip())
+
+        if status_code == 400:
+            if message is not None:
+                await message.reply_text(f"❌ {res.get('detail', 'Invalid amount')} Try again.")
+            return RECHARGE_AWAIT_AMOUNT
+
+        if message is not None:
+            await message.reply_text(self._format_recharge_result(username, text.strip(), status_code, res))
+
+        context.chat_data.pop("recharge_target", None)
+        context.chat_data.pop("recharge_all_users", None)
+        return ConversationHandler.END
+
+    @safe_handler
+    async def recharge_cancel(self, update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._cancel_user_flow(update, context, "recharge")
+
+    @safe_handler
+    async def adjust_entry(self, update, context: ContextTypes.DEFAULT_TYPE):
+        chat = getattr(update, "effective_chat", None)
+        chat_id = getattr(chat, "id", None)
+        args = getattr(context, "args", None) or []
+        message = getattr(update, "message", None)
+
+        if len(args) == 2:
+            # Fallback one-shot form: /adjust <username> <new_balance>
+            username = args[0]
+            status_code, res = await self.user_service.adjust(chat_id, username, args[1])
+            if message is not None:
+                await message.reply_text(self._format_adjust_result(username, status_code, res))
+            return ConversationHandler.END
+
+        return await self._start_user_search(update, context, "adjust")
+
+    @safe_handler
+    async def adjust_search(self, update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._handle_user_search_text(update, context, "adjust", ADJUST_SEARCH, ADJUST_AWAIT_AMOUNT)
+
+    @safe_handler
+    async def adjust_choose_user(self, update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._handle_user_choice_callback(update, context, "adjust", ADJUST_AWAIT_AMOUNT)
+
+    @safe_handler
+    async def adjust_receive_amount(self, update, context: ContextTypes.DEFAULT_TYPE):
+        chat = getattr(update, "effective_chat", None)
+        chat_id = getattr(chat, "id", None)
+        message = getattr(update, "message", None)
+        text = getattr(message, "text", "") if message is not None else ""
+
+        user = context.chat_data.get("adjust_target")
+        if user is None:
+            if message is not None:
+                await message.reply_text("⚠️ Session expired. Run /adjust again.")
+            return ConversationHandler.END
+
+        username = user.get("username")
+        status_code, res = await self.user_service.adjust(chat_id, username, text.strip())
+
+        if status_code == 400:
+            if message is not None:
+                await message.reply_text(f"❌ {res.get('detail', 'Invalid amount')} Try again.")
+            return ADJUST_AWAIT_AMOUNT
+
+        if message is not None:
+            await message.reply_text(self._format_adjust_result(username, status_code, res))
+
+        context.chat_data.pop("adjust_target", None)
+        context.chat_data.pop("adjust_all_users", None)
+        return ConversationHandler.END
+
+    @safe_handler
+    async def adjust_cancel(self, update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._cancel_user_flow(update, context, "adjust")
+
+    @safe_handler
+    async def cancel_command(self, update, context: ContextTypes.DEFAULT_TYPE):
+        """Shared /cancel fallback for the /stock, /expense, /recharge, and
+        /adjust guided flows."""
+        for key in (
+            "stock_target", "stock_items", "stock_delta", "pending_expense",
+            "recharge_target", "recharge_all_users", "adjust_target", "adjust_all_users",
+        ):
+            context.chat_data.pop(key, None)
+        message = getattr(update, "message", None)
+        if message is not None:
+            await message.reply_text("❌ Cancelled.")
+        return ConversationHandler.END
+
+    # ---- /stock: guided item picker + button stepper, one-shot args as fallback ----
+
+    STOCK_STEPS = (-50, -10, -1, 1, 10, 50)
+
+    def _build_stock_item_buttons(self, items: list[dict]) -> InlineKeyboardMarkup:
+        buttons = []
+        for item in items:
+            warn = "⚠️ " if item.get("is_low_stock") else ""
+            label = f"{warn}{item.get('name')} ({item.get('current_stock'):g} {item.get('unit')})"
+            buttons.append([InlineKeyboardButton(label, callback_data=f"stock:item:{item.get('id')}")])
+        buttons.append([InlineKeyboardButton("❌ Cancel", callback_data="stock:cancel")])
+        return InlineKeyboardMarkup(buttons)
+
+    def _format_delta(self, delta: float) -> str:
+        return f"+{delta:g}" if delta > 0 else f"{delta:g}"
+
+    def _format_stock_stepper_text(self, item: dict, delta: float) -> str:
+        current = item.get("current_stock", 0)
+        unit = item.get("unit", "")
+        new_stock = current + delta
+        change = self._format_delta(delta) if delta else "0"
+        return (
+            f"📦 <b>{self._escape_html(item.get('name'))}</b>\n"
+            f"Current stock: {current:g} {unit}\n"
+            f"Change: {change}\n"
+            f"New stock: {new_stock:g} {unit}\n\n"
+            "Use the buttons below, then Confirm."
+        )
+
+    def _build_stock_stepper_buttons(self, delta: float) -> InlineKeyboardMarkup:
+        step_row = [
+            InlineKeyboardButton(self._format_delta(step), callback_data=f"stock:step:{step}")
+            for step in self.STOCK_STEPS
+        ]
+        return InlineKeyboardMarkup([
+            step_row,
+            [
+                InlineKeyboardButton("✅ Confirm", callback_data="stock:confirm"),
+                InlineKeyboardButton("❌ Cancel", callback_data="stock:cancel"),
+            ],
+        ])
+
+    def _format_stock_result_text(self, item_name: str, delta, status_code: int, res: dict) -> str:
+        if status_code == 200:
+            name = res.get("name") or item_name
+            unit = res.get("unit") or ""
+            new_stock = res.get("current_stock")
+            try:
+                old_stock = new_stock - float(delta)
+                return f"📦 {name}: {old_stock:g} → {new_stock:g} {unit}"
+            except Exception:
+                return f"📦 {name}: now {new_stock} {unit}"
+        elif status_code == 403:
+            return "❌ You are not authorized to manage inventory."
+        elif status_code == 404:
+            return f"⚠️ Item not found: {item_name}. Run /stock to see the list."
+        elif status_code == 400:
+            return f"❌ {res.get('detail', 'Invalid amount')}"
+        else:
+            return f"⚠️ Error: {res.get('detail', 'Unknown error')}"
+
+    async def _reply_stock_result(self, message, item_name: str, delta, status_code: int, res: dict):
+        if message is not None:
+            await message.reply_text(self._format_stock_result_text(item_name, delta, status_code, res))
+
+    async def _edit_stock_result(self, message, item_name: str, delta, status_code: int, res: dict):
+        if message is not None:
+            await message.edit_text(self._format_stock_result_text(item_name, delta, status_code, res))
+
+    @safe_handler
+    async def stock_entry(self, update, context: ContextTypes.DEFAULT_TYPE):
+        chat = getattr(update, "effective_chat", None)
+        chat_id = getattr(chat, "id", None)
+        args = getattr(context, "args", None) or []
+        message = getattr(update, "message", None)
+
+        if len(args) >= 2:
+            # Fallback one-shot form: /stock <delta> <item name...>
+            delta_raw = args[0]
+            item_name = " ".join(args[1:])
+            status_code, res = await self.user_service.adjust_stock(chat_id, item_name, delta_raw)
+            await self._reply_stock_result(message, item_name, delta_raw, status_code, res)
+            return ConversationHandler.END
+
+        status_code, res = await self.user_service.list_inventory(chat_id)
+        if status_code == 403:
+            if message is not None:
+                await message.reply_text("❌ You are not authorized to manage inventory.")
+            return ConversationHandler.END
+        if status_code != 200:
+            if message is not None:
                 await message.reply_text(f"⚠️ Error: {res.get('detail', 'Unknown error')}")
+            return ConversationHandler.END
+        if not res:
+            if message is not None:
+                await message.reply_text("No inventory items found.")
+            return ConversationHandler.END
+
+        context.chat_data["stock_items"] = {str(item["id"]): item for item in res}
+        if message is not None:
+            await message.reply_text("📦 Select an item to adjust:", reply_markup=self._build_stock_item_buttons(res))
+        return STOCK_CHOOSE_ITEM
+
+    @safe_handler
+    async def stock_choose_item(self, update, context: ContextTypes.DEFAULT_TYPE):
+        query = getattr(update, "callback_query", None)
+        if query is None:
+            return ConversationHandler.END
+
+        data = getattr(query, "data", None) or ""
+        item_id = data.split(":", 2)[-1]
+        items = context.chat_data.get("stock_items") or {}
+        item = items.get(item_id)
+
+        await query.answer()
+        msg = getattr(query, "message", None)
+        if item is None:
+            if msg is not None:
+                await msg.edit_text("⚠️ That item is no longer available. Run /stock again.")
+            return ConversationHandler.END
+
+        context.chat_data["stock_target"] = item
+        context.chat_data["stock_delta"] = 0.0
+        if msg is not None:
+            await msg.edit_text(
+                self._format_stock_stepper_text(item, 0.0),
+                reply_markup=self._build_stock_stepper_buttons(0.0),
+                parse_mode="HTML",
+            )
+        return STOCK_ADJUST_DELTA
+
+    @safe_handler
+    async def stock_step(self, update, context: ContextTypes.DEFAULT_TYPE):
+        query = getattr(update, "callback_query", None)
+        if query is None:
+            return ConversationHandler.END
+
+        item = context.chat_data.get("stock_target")
+        if item is None:
+            await query.answer("Session expired. Run /stock again.", show_alert=True)
+            return ConversationHandler.END
+
+        data = getattr(query, "data", None) or ""
+        try:
+            step = float(data.split(":", 2)[-1])
+        except Exception:
+            step = 0.0
+
+        delta = context.chat_data.get("stock_delta", 0.0) + step
+        context.chat_data["stock_delta"] = delta
+
+        await query.answer()
+        msg = getattr(query, "message", None)
+        if msg is not None:
+            await msg.edit_text(
+                self._format_stock_stepper_text(item, delta),
+                reply_markup=self._build_stock_stepper_buttons(delta),
+                parse_mode="HTML",
+            )
+        return STOCK_ADJUST_DELTA
+
+    @safe_handler
+    async def stock_confirm(self, update, context: ContextTypes.DEFAULT_TYPE):
+        query = getattr(update, "callback_query", None)
+        if query is None:
+            return ConversationHandler.END
+
+        item = context.chat_data.get("stock_target")
+        delta = context.chat_data.get("stock_delta", 0.0)
+        if item is None:
+            await query.answer("Session expired. Run /stock again.", show_alert=True)
+            return ConversationHandler.END
+
+        if delta == 0:
+            await query.answer("Change the amount before confirming.", show_alert=True)
+            return STOCK_ADJUST_DELTA
+
+        msg = getattr(query, "message", None)
+        chat = getattr(msg, "chat", None)
+        chat_id = getattr(chat, "id", None)
+        status_code, res = await self.user_service.adjust_stock(chat_id, item.get("name"), delta)
+
+        if status_code == 200:
+            await query.answer("Stock updated")
+        elif status_code == 403:
+            await query.answer("You are not authorized to manage inventory.", show_alert=True)
+        else:
+            await query.answer(res.get("detail", "Unknown error"), show_alert=True)
+
+        await self._edit_stock_result(msg, item.get("name"), delta, status_code, res)
+
+        context.chat_data.pop("stock_target", None)
+        context.chat_data.pop("stock_items", None)
+        context.chat_data.pop("stock_delta", None)
+        return ConversationHandler.END
+
+    @safe_handler
+    async def stock_cancel(self, update, context: ContextTypes.DEFAULT_TYPE):
+        query = getattr(update, "callback_query", None)
+        context.chat_data.pop("stock_target", None)
+        context.chat_data.pop("stock_items", None)
+        context.chat_data.pop("stock_delta", None)
+        if query is not None:
+            await query.answer("Cancelled")
+            msg = getattr(query, "message", None)
+            if msg is not None:
+                await msg.edit_text("❌ Cancelled.")
+        return ConversationHandler.END
+
+    # ---- /expense: guided category/amount/description + confirm, one-shot args as fallback ----
+
+    def _build_expense_category_buttons(self) -> InlineKeyboardMarkup:
+        row = [
+            InlineKeyboardButton(EXPENSE_CATEGORY_LABELS[c], callback_data=f"expense:cat:{c}")
+            for c in EXPENSE_CATEGORIES
+        ]
+        return InlineKeyboardMarkup([row, [InlineKeyboardButton("❌ Cancel", callback_data="expense:cancel")]])
+
+    def _build_expense_confirm_buttons(self) -> InlineKeyboardMarkup:
+        return InlineKeyboardMarkup([[
+            InlineKeyboardButton("✅ Confirm", callback_data="expense:confirm"),
+            InlineKeyboardButton("❌ Cancel", callback_data="expense:cancel"),
+        ]])
+
+    def _format_expense_summary(self, category, amount, description, header="📝 <b>Confirm expense</b>") -> str:
+        lines = [
+            header,
+            "",
+            f"Category: {self._escape_html(category)}",
+            f"Amount: {float(amount):.2f}€",
+        ]
+        if description:
+            lines.append(f"Description: {self._escape_html(description)}")
+        return "\n".join(lines)
+
+    async def _show_expense_confirmation(self, update, context: ContextTypes.DEFAULT_TYPE, *, edit: bool):
+        pending = context.chat_data.get("pending_expense") or {}
+        text = self._format_expense_summary(pending.get("category"), pending.get("amount"), pending.get("description"))
+        buttons = self._build_expense_confirm_buttons()
+
+        if edit:
+            query = getattr(update, "callback_query", None)
+            msg = getattr(query, "message", None) if query is not None else None
+            if msg is not None:
+                await msg.edit_text(text, reply_markup=buttons, parse_mode="HTML")
+        else:
+            message = getattr(update, "message", None)
+            if message is not None:
+                await message.reply_text(text, reply_markup=buttons, parse_mode="HTML")
+        return EXPENSE_CONFIRM
+
+    async def _start_expense_confirmation(self, update, context: ContextTypes.DEFAULT_TYPE, category, amount, description):
+        ok, normalized_category, a, error = validate_expense_input(category, amount)
+        message = getattr(update, "message", None)
+        if not ok:
+            if message is not None:
+                await message.reply_text(f"❌ {error}")
+            return ConversationHandler.END
+
+        context.chat_data["pending_expense"] = {
+            "category": normalized_category,
+            "amount": a,
+            "description": description,
+        }
+        return await self._show_expense_confirmation(update, context, edit=False)
+
+    @safe_handler
+    async def expense_entry(self, update, context: ContextTypes.DEFAULT_TYPE):
+        args = getattr(context, "args", None) or []
+        message = getattr(update, "message", None)
+
+        if len(args) >= 2:
+            # Fallback one-shot form: /expense <category> <amount> [description...]
+            category = args[0]
+            amount = args[1]
+            description = " ".join(args[2:]).strip() or None
+            return await self._start_expense_confirmation(update, context, category, amount, description)
+
+        if message is not None:
+            await message.reply_text("🧾 Select an expense category:", reply_markup=self._build_expense_category_buttons())
+        return EXPENSE_CHOOSE_CATEGORY
+
+    @safe_handler
+    async def expense_choose_category(self, update, context: ContextTypes.DEFAULT_TYPE):
+        query = getattr(update, "callback_query", None)
+        if query is None:
+            return ConversationHandler.END
+
+        data = getattr(query, "data", None) or ""
+        category = data.split(":", 2)[-1]
+        await query.answer()
+
+        context.chat_data["pending_expense"] = {"category": category}
+        msg = getattr(query, "message", None)
+        if msg is not None:
+            await msg.edit_text(f"Category: {EXPENSE_CATEGORY_LABELS.get(category, category)}\n\nHow much did it cost? (e.g. 15.50)")
+        return EXPENSE_AWAIT_AMOUNT
+
+    @safe_handler
+    async def expense_receive_amount(self, update, context: ContextTypes.DEFAULT_TYPE):
+        message = getattr(update, "message", None)
+        text = getattr(message, "text", "") if message is not None else ""
+        pending = context.chat_data.get("pending_expense")
+
+        if pending is None:
+            if message is not None:
+                await message.reply_text("⚠️ Session expired. Run /expense again.")
+            return ConversationHandler.END
+
+        try:
+            amount = float(text.strip())
+        except Exception:
+            if message is not None:
+                await message.reply_text("❌ That's not a valid number. How much did it cost? (e.g. 15.50)")
+            return EXPENSE_AWAIT_AMOUNT
+
+        if amount <= 0:
+            if message is not None:
+                await message.reply_text("❌ Amount must be positive. How much did it cost?")
+            return EXPENSE_AWAIT_AMOUNT
+
+        pending["amount"] = amount
+        if message is not None:
+            await message.reply_text(
+                "Add a description, or tap Skip.",
+                reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("⏭ Skip", callback_data="expense:skip_desc")]]),
+            )
+        return EXPENSE_AWAIT_DESCRIPTION
+
+    @safe_handler
+    async def expense_receive_description(self, update, context: ContextTypes.DEFAULT_TYPE):
+        message = getattr(update, "message", None)
+        text = getattr(message, "text", "") if message is not None else ""
+        pending = context.chat_data.get("pending_expense")
+
+        if pending is None:
+            if message is not None:
+                await message.reply_text("⚠️ Session expired. Run /expense again.")
+            return ConversationHandler.END
+
+        pending["description"] = text.strip() or None
+        return await self._show_expense_confirmation(update, context, edit=False)
+
+    @safe_handler
+    async def expense_skip_description(self, update, context: ContextTypes.DEFAULT_TYPE):
+        query = getattr(update, "callback_query", None)
+        if query is None:
+            return ConversationHandler.END
+
+        await query.answer()
+        pending = context.chat_data.get("pending_expense")
+        if pending is None:
+            msg = getattr(query, "message", None)
+            if msg is not None:
+                await msg.edit_text("⚠️ Session expired. Run /expense again.")
+            return ConversationHandler.END
+
+        pending["description"] = None
+        return await self._show_expense_confirmation(update, context, edit=True)
+
+    @safe_handler
+    async def expense_confirm(self, update, context: ContextTypes.DEFAULT_TYPE):
+        query = getattr(update, "callback_query", None)
+        if query is None:
+            return ConversationHandler.END
+
+        msg = getattr(query, "message", None)
+        chat = getattr(msg, "chat", None)
+        chat_id = getattr(chat, "id", None)
+        pending = context.chat_data.pop("pending_expense", None)
+
+        if pending is None:
+            await query.answer("Nothing to confirm — run /expense again.", show_alert=True)
+            return ConversationHandler.END
+
+        status_code, res = await self.user_service.create_expense(
+            chat_id, pending.get("category"), pending.get("amount"), pending.get("description"),
+        )
+
+        if status_code in (200, 201):
+            await query.answer("Expense logged")
+            if msg is not None:
+                await msg.edit_text(
+                    self._format_expense_summary(
+                        pending.get("category"), pending.get("amount"), pending.get("description"),
+                        header="✅ <b>Expense logged</b>",
+                    ),
+                    parse_mode="HTML",
+                )
+        elif status_code == 403:
+            await query.answer("You are not authorized to log expenses.", show_alert=True)
+        else:
+            await query.answer(res.get("detail", "Unknown error"), show_alert=True)
+        return ConversationHandler.END
+
+    @safe_handler
+    async def expense_cancel(self, update, context: ContextTypes.DEFAULT_TYPE):
+        query = getattr(update, "callback_query", None)
+        context.chat_data.pop("pending_expense", None)
+        if query is not None:
+            await query.answer("Cancelled")
+            msg = getattr(query, "message", None)
+            if msg is not None:
+                await msg.edit_text("❌ Expense cancelled.")
+        return ConversationHandler.END

--- a/src/bot_handlers.py
+++ b/src/bot_handlers.py
@@ -145,12 +145,25 @@ class BotHandlers:
             self.recharge_request_notifications[request_id] = notifications
 
     async def _mark_request_messages_resolved(self, context: ContextTypes.DEFAULT_TYPE, payload: dict):
-        request_id = payload.get("request", {}).get("id")
+        request = payload.get("request", {})
+        request_id = request.get("id")
         if not request_id:
             return
 
         text = self._build_resolution_text(payload)
         notifications = self.recharge_request_notifications.pop(request_id, [])
+
+        # Requests created from the web app were never announced by this
+        # bot process (the backend messaged the target admin directly), so
+        # they're never in the in-memory map above — but the backend
+        # persists the one message it sent on the request row itself,
+        # which survives a bot restart unlike the in-memory map.
+        if not notifications and request.get("notified_chat_id") and request.get("notified_message_id"):
+            notifications = [{
+                "chat_id": int(request["notified_chat_id"]),
+                "message_id": request["notified_message_id"],
+            }]
+
         for notification in notifications:
             try:
                 await context.bot.edit_message_text(

--- a/src/bot_handlers.py
+++ b/src/bot_handlers.py
@@ -637,7 +637,10 @@ class BotHandlers:
                 )
         return next_state
 
-    async def _prompt_for_amount(self, update, context: ContextTypes.DEFAULT_TYPE, user: dict, prefix: str, prompt_text: str, next_state, *, edit: bool):
+    async def _prompt_for_amount(
+        self, update, context: ContextTypes.DEFAULT_TYPE, user: dict, prefix: str,
+        prompt_text: str, next_state, *, edit: bool,
+    ):
         context.chat_data[f"{prefix}_target"] = user
         if edit:
             query = getattr(update, "callback_query", None)

--- a/src/services.py
+++ b/src/services.py
@@ -5,6 +5,29 @@ from .logger import LOGGER_MANAGER
 from .config import get_config
 
 
+EXPENSE_CATEGORIES = ("toner", "paper", "maintenance", "other")
+
+
+def validate_expense_input(category, amount) -> Tuple[bool, str, float, Optional[str]]:
+    """Shared by UserService.create_expense (before hitting the backend)
+    and the bot's /expense entry point (before showing the confirm
+    screen for the one-shot fallback form) — one source of truth for
+    what counts as a valid expense."""
+    normalized_category = str(category).strip().lower()
+    if normalized_category not in EXPENSE_CATEGORIES:
+        return False, normalized_category, 0.0, f"Category must be one of: {', '.join(EXPENSE_CATEGORIES)}"
+
+    try:
+        a = float(amount)
+    except Exception:
+        return False, normalized_category, 0.0, "Amount must be a number"
+
+    if a <= 0:
+        return False, normalized_category, 0.0, "Amount must be positive"
+
+    return True, normalized_category, a, None
+
+
 class UserService:
     def __init__(self, client: APIClient, logger=None):
         self.client = client
@@ -95,6 +118,53 @@ class UserService:
             request_id,
             action,
             status,
+        )
+        return status, res
+
+    async def resolve_product_purchase(self, chat_id: int, purchase_id: str, action: str) -> Tuple[int, dict]:
+        status, res = await self.client.resolve_product_purchase(chat_id, purchase_id, action)
+        self.logger.info(
+            "resolve_product_purchase chat_id=%s purchase_id=%s action=%s status=%s",
+            chat_id,
+            purchase_id,
+            action,
+            status,
+        )
+        return status, res
+
+    async def list_inventory(self, chat_id: int) -> Tuple[int, Union[list, dict, Any]]:
+        status, res = await self.client.get_inventory(chat_id)
+        self.logger.info("list_inventory chat_id=%s status=%s", chat_id, status)
+        return status, res
+
+    async def adjust_stock(self, chat_id: int, item_name: str, delta) -> Tuple[int, dict]:
+        try:
+            d = float(delta)
+        except Exception:
+            self.logger.warning("Invalid stock delta: %s by chat_id=%s", delta, chat_id)
+            return 400, {"detail": "Amount must be a number"}
+
+        if d == 0:
+            self.logger.warning("Zero stock delta by chat_id=%s", chat_id)
+            return 400, {"detail": "Amount cannot be zero"}
+
+        status, res = await self.client.adjust_stock(chat_id, item_name, d)
+        self.logger.info(
+            "adjust_stock chat_id=%s item_name=%s delta=%s status=%s", chat_id, item_name, d, status
+        )
+        return status, res
+
+    async def create_expense(self, chat_id: int, category, amount, description: str | None = None) -> Tuple[int, dict]:
+        ok, normalized_category, a, error = validate_expense_input(category, amount)
+        if not ok:
+            self.logger.warning(
+                "Invalid expense input category=%s amount=%s by chat_id=%s", category, amount, chat_id
+            )
+            return 400, {"detail": error}
+
+        status, res = await self.client.create_expense(chat_id, normalized_category, a, description)
+        self.logger.info(
+            "create_expense chat_id=%s category=%s amount=%s status=%s", chat_id, normalized_category, a, status
         )
         return status, res
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,18 @@ class FakeAPIClient:
     async def resolve_recharge_request(self, chat_id, request_id, action):
         return await self._record("resolve_recharge_request", chat_id, request_id, action)
 
+    async def resolve_product_purchase(self, chat_id, purchase_id, action):
+        return await self._record("resolve_product_purchase", chat_id, purchase_id, action)
+
+    async def get_inventory(self, chat_id):
+        return await self._record("get_inventory", chat_id)
+
+    async def adjust_stock(self, chat_id, item_name, delta):
+        return await self._record("adjust_stock", chat_id, item_name, delta)
+
+    async def create_expense(self, chat_id, category, amount, description=None):
+        return await self._record("create_expense", chat_id, category, amount, description)
+
 
 @pytest.fixture
 def fake_client():

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -48,3 +48,41 @@ async def test_close_logs_when_aclose_fails(caplog):
         await client.close()
 
     assert "Failed to close the HTTP client cleanly" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_get_inventory_calls_expected_path():
+    client = make_client()
+    client._get = AsyncMock(return_value=(200, []))
+
+    status, res = await client.get_inventory(123)
+
+    assert status == 200
+    client._get.assert_awaited_once_with("/telegram/inventory", json={"chat_id": "123"})
+
+
+@pytest.mark.asyncio
+async def test_adjust_stock_calls_expected_path():
+    client = make_client()
+    client._patch = AsyncMock(return_value=(200, {}))
+
+    status, res = await client.adjust_stock(123, "A4 Paper", -50.0)
+
+    assert status == 200
+    client._patch.assert_awaited_once_with(
+        "/telegram/stock-adjust", json={"chat_id": "123", "item_name": "A4 Paper", "delta": -50.0}
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_expense_calls_expected_path():
+    client = make_client()
+    client._post = AsyncMock(return_value=(201, {"success": True}))
+
+    status, res = await client.create_expense(123, "toner", 15.5, "cartridge")
+
+    assert status == 201
+    client._post.assert_awaited_once_with(
+        "/telegram/expenses",
+        json={"chat_id": "123", "category": "toner", "amount": 15.5, "description": "cartridge"},
+    )

--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -29,3 +29,62 @@ async def test_button_callback_logs_when_answer_fails(caplog):
 
     query.answer.assert_awaited_once()
     assert "Failed to answer callback query for request req123" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mark_resolved_falls_back_to_db_tracked_message():
+    """A request created from the web app was never announced by this bot
+    process, so it's never in the in-memory notifications map — the only
+    way to edit its Telegram message is the notified_chat_id/message_id
+    the backend persisted on the request row itself."""
+    fake_client = FakeAPIClient(response=(200, {}))
+    handlers = BotHandlers(services={"user": UserService(fake_client)})
+    context = SimpleNamespace(bot=AsyncMock())
+
+    payload = {
+        "request": {
+            "id": "web-created-req",
+            "status": "approved",
+            "resolved_by_username": "admin_bob",
+            "notified_chat_id": "555",
+            "notified_message_id": 999,
+        },
+        "user_name": "Test",
+        "user_surname": "User",
+    }
+
+    await handlers._mark_request_messages_resolved(context, payload)
+
+    context.bot.edit_message_text.assert_awaited_once()
+    _, kwargs = context.bot.edit_message_text.call_args
+    assert kwargs["chat_id"] == 555
+    assert kwargs["message_id"] == 999
+
+
+@pytest.mark.asyncio
+async def test_mark_resolved_prefers_in_memory_notifications_when_present():
+    """Bot-created (broadcast) requests are still tracked in-memory —
+    that path must keep working unchanged, and must NOT also fall back to
+    (nonexistent) notified_chat_id/message_id fields."""
+    fake_client = FakeAPIClient(response=(200, {}))
+    handlers = BotHandlers(services={"user": UserService(fake_client)})
+    handlers.recharge_request_notifications["bot-created-req"] = [
+        {"chat_id": 111, "message_id": 222},
+        {"chat_id": 333, "message_id": 444},
+    ]
+    context = SimpleNamespace(bot=AsyncMock())
+
+    payload = {
+        "request": {
+            "id": "bot-created-req",
+            "status": "rejected",
+            "resolved_by_username": "admin_bob",
+        },
+        "user_name": "Test",
+        "user_surname": "User",
+    }
+
+    await handlers._mark_request_messages_resolved(context, payload)
+
+    assert context.bot.edit_message_text.await_count == 2
+    assert "bot-created-req" not in handlers.recharge_request_notifications

--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -4,15 +4,42 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from src.bot_handlers import BotHandlers
+from src.bot_handlers import (
+    BotHandlers,
+    STOCK_CHOOSE_ITEM,
+    STOCK_ADJUST_DELTA,
+    EXPENSE_CHOOSE_CATEGORY,
+    EXPENSE_AWAIT_AMOUNT,
+    EXPENSE_AWAIT_DESCRIPTION,
+    EXPENSE_CONFIRM,
+    RECHARGE_SEARCH,
+    RECHARGE_AWAIT_AMOUNT,
+    ADJUST_SEARCH,
+    ADJUST_AWAIT_AMOUNT,
+)
 from src.services import UserService
+from telegram.ext import ConversationHandler
 from tests.conftest import FakeAPIClient
 
 
 def make_query(data, answer_side_effect=None):
     answer = AsyncMock(side_effect=answer_side_effect)
-    message = SimpleNamespace(chat=SimpleNamespace(id=123), reply_text=AsyncMock())
+    message = SimpleNamespace(chat=SimpleNamespace(id=123), reply_text=AsyncMock(), edit_text=AsyncMock())
     return SimpleNamespace(data=data, message=message, answer=answer)
+
+
+def make_command_update(args=None, chat_id=123):
+    message = SimpleNamespace(reply_text=AsyncMock())
+    update = SimpleNamespace(effective_chat=SimpleNamespace(id=chat_id), message=message)
+    context = SimpleNamespace(args=args or [], chat_data={})
+    return update, context, message
+
+
+def make_text_update(text, chat_data=None, chat_id=123):
+    message = SimpleNamespace(text=text, reply_text=AsyncMock())
+    update = SimpleNamespace(effective_chat=SimpleNamespace(id=chat_id), message=message)
+    context = SimpleNamespace(args=[], chat_data=chat_data if chat_data is not None else {})
+    return update, context, message
 
 
 @pytest.mark.asyncio
@@ -88,3 +115,623 @@ async def test_mark_resolved_prefers_in_memory_notifications_when_present():
 
     assert context.bot.edit_message_text.await_count == 2
     assert "bot-created-req" not in handlers.recharge_request_notifications
+
+
+@pytest.mark.asyncio
+async def test_button_callback_resolves_purchase_and_edits_every_admin_notification():
+    """A purchase is broadcast to every admin, not just one — resolving it
+    from a Telegram button must edit every one of those messages, using
+    the notifications list the backend hands back (there's no in-memory
+    tracking for this at all, since the backend always sent these)."""
+    response = (200, {
+        "purchase": {
+            "id": "purchase123",
+            "username": "alice",
+            "product_name": "Spiral Binding",
+            "quantity": 2,
+            "total_amount": 2.0,
+            "status": "fulfilled",
+            "admin_message": None,
+            "resolved_by_username": "admin_bob",
+        },
+        "notifications": [
+            {"chat_id": "111", "message_id": 222},
+            {"chat_id": "333", "message_id": 444},
+        ],
+    })
+    fake_client = FakeAPIClient(response=response)
+    handlers = BotHandlers(services={"user": UserService(fake_client)})
+
+    query = make_query("pp:fulfill:purchase123")
+    update = SimpleNamespace(callback_query=query)
+    context = SimpleNamespace(bot=AsyncMock())
+
+    await handlers.button_callback(update, context)
+
+    assert ("resolve_product_purchase", (123, "purchase123", "fulfill"), {}) in fake_client.calls
+    assert context.bot.edit_message_text.await_count == 2
+    query.answer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_button_callback_purchase_already_resolved_shows_alert():
+    response = (409, {"detail": "Purchase has already been resolved", "resolved_by_username": "admin_ana"})
+    fake_client = FakeAPIClient(response=response)
+    handlers = BotHandlers(services={"user": UserService(fake_client)})
+
+    query = make_query("pp:reject:purchase123")
+    update = SimpleNamespace(callback_query=query)
+    context = SimpleNamespace(bot=AsyncMock())
+
+    await handlers.button_callback(update, context)
+
+    query.answer.assert_awaited_once()
+    args, kwargs = query.answer.call_args
+    assert "admin_ana" in args[0]
+    assert kwargs["show_alert"] is True
+    assert context.bot.edit_message_text.await_count == 0
+
+
+class TestStockFlow:
+    @pytest.mark.asyncio
+    async def test_entry_fallback_args_applies_immediately(self):
+        fake_client = FakeAPIClient(response=(200, {"name": "A4 Paper", "current_stock": 70.0, "unit": "sheets"}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_command_update(args=["-30", "A4", "Paper"])
+
+        result = await handlers.stock_entry(update, context)
+
+        assert result == ConversationHandler.END
+        assert fake_client.calls == [("adjust_stock", (123, "A4 Paper", -30.0), {})]
+        message.reply_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_entry_no_args_lists_items_and_enters_choose_item(self):
+        items = [{"id": "item1", "name": "A4 Paper", "current_stock": 100.0, "unit": "sheets", "is_low_stock": False}]
+        fake_client = FakeAPIClient(response=(200, items))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_command_update(args=[])
+
+        result = await handlers.stock_entry(update, context)
+
+        assert result == STOCK_CHOOSE_ITEM
+        assert context.chat_data["stock_items"] == {"item1": items[0]}
+        message.reply_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_entry_forbidden_ends_conversation(self):
+        fake_client = FakeAPIClient(response=(403, {"detail": "nope"}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_command_update(args=[])
+
+        result = await handlers.stock_entry(update, context)
+
+        assert result == ConversationHandler.END
+
+    @pytest.mark.asyncio
+    async def test_choose_item_stores_target_and_shows_stepper(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        item = {"id": "item1", "name": "A4 Paper", "current_stock": 100.0, "unit": "sheets"}
+        query = make_query("stock:item:item1")
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace(chat_data={"stock_items": {"item1": item}})
+
+        result = await handlers.stock_choose_item(update, context)
+
+        assert result == STOCK_ADJUST_DELTA
+        assert context.chat_data["stock_target"] == item
+        assert context.chat_data["stock_delta"] == 0.0
+        query.message.edit_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_step_accumulates_delta_and_stays_in_state(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        item = {"id": "item1", "name": "A4 Paper", "current_stock": 100.0, "unit": "sheets"}
+        query = make_query("stock:step:10")
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace(chat_data={"stock_target": item, "stock_delta": 5.0})
+
+        result = await handlers.stock_step(update, context)
+
+        assert result == STOCK_ADJUST_DELTA
+        assert context.chat_data["stock_delta"] == 15.0
+        assert fake_client.calls == []
+        query.message.edit_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_step_with_negative_button_subtracts(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        item = {"id": "item1", "name": "A4 Paper", "current_stock": 100.0, "unit": "sheets"}
+        query = make_query("stock:step:-50")
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace(chat_data={"stock_target": item, "stock_delta": 0.0})
+
+        result = await handlers.stock_step(update, context)
+
+        assert result == STOCK_ADJUST_DELTA
+        assert context.chat_data["stock_delta"] == -50.0
+
+    @pytest.mark.asyncio
+    async def test_confirm_with_zero_delta_shows_alert_and_stays(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        item = {"id": "item1", "name": "A4 Paper", "current_stock": 100.0, "unit": "sheets"}
+        query = make_query("stock:confirm")
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace(chat_data={"stock_target": item, "stock_delta": 0.0})
+
+        result = await handlers.stock_confirm(update, context)
+
+        assert result == STOCK_ADJUST_DELTA
+        assert fake_client.calls == []
+        query.answer.assert_awaited_once()
+        args, kwargs = query.answer.call_args
+        assert kwargs.get("show_alert") is True
+
+    @pytest.mark.asyncio
+    async def test_confirm_with_delta_applies_and_ends(self):
+        fake_client = FakeAPIClient(response=(200, {"name": "A4 Paper", "current_stock": 70.0, "unit": "sheets"}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        item = {"id": "item1", "name": "A4 Paper", "current_stock": 100.0, "unit": "sheets"}
+        query = make_query("stock:confirm")
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace(chat_data={"stock_target": item, "stock_delta": -30.0, "stock_items": {}})
+
+        result = await handlers.stock_confirm(update, context)
+
+        assert result == ConversationHandler.END
+        assert fake_client.calls == [("adjust_stock", (123, "A4 Paper", -30.0), {})]
+        assert "stock_target" not in context.chat_data
+        assert "stock_delta" not in context.chat_data
+        query.message.edit_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cancel_clears_state(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        query = make_query("stock:cancel")
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace(chat_data={"stock_target": {}, "stock_items": {}, "stock_delta": 5.0})
+
+        result = await handlers.stock_cancel(update, context)
+
+        assert result == ConversationHandler.END
+        assert context.chat_data == {}
+        query.message.edit_text.assert_awaited_once()
+
+
+class TestExpenseFlow:
+    @pytest.mark.asyncio
+    async def test_entry_fallback_valid_args_shows_confirm(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_command_update(args=["toner", "15.5", "cartridge"])
+
+        result = await handlers.expense_entry(update, context)
+
+        assert result == EXPENSE_CONFIRM
+        assert fake_client.calls == []  # not submitted yet — confirm required
+        assert context.chat_data["pending_expense"] == {"category": "toner", "amount": 15.5, "description": "cartridge"}
+        message.reply_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_entry_fallback_invalid_args_ends_without_confirm(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_command_update(args=["snacks", "15.5"])
+
+        result = await handlers.expense_entry(update, context)
+
+        assert result == ConversationHandler.END
+        assert "pending_expense" not in context.chat_data
+
+    @pytest.mark.asyncio
+    async def test_entry_no_args_enters_choose_category(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_command_update(args=[])
+
+        result = await handlers.expense_entry(update, context)
+
+        assert result == EXPENSE_CHOOSE_CATEGORY
+        message.reply_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_choose_category_stores_pending_and_prompts_for_amount(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        query = make_query("expense:cat:toner")
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace(chat_data={})
+
+        result = await handlers.expense_choose_category(update, context)
+
+        assert result == EXPENSE_AWAIT_AMOUNT
+        assert context.chat_data["pending_expense"] == {"category": "toner"}
+
+    @pytest.mark.asyncio
+    async def test_receive_amount_invalid_reprompts(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_text_update("not-a-number", chat_data={"pending_expense": {"category": "toner"}})
+
+        result = await handlers.expense_receive_amount(update, context)
+
+        assert result == EXPENSE_AWAIT_AMOUNT
+
+    @pytest.mark.asyncio
+    async def test_receive_amount_non_positive_reprompts(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_text_update("0", chat_data={"pending_expense": {"category": "toner"}})
+
+        result = await handlers.expense_receive_amount(update, context)
+
+        assert result == EXPENSE_AWAIT_AMOUNT
+
+    @pytest.mark.asyncio
+    async def test_receive_amount_valid_moves_to_description(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        pending = {"category": "toner"}
+        update, context, message = make_text_update("15.5", chat_data={"pending_expense": pending})
+
+        result = await handlers.expense_receive_amount(update, context)
+
+        assert result == EXPENSE_AWAIT_DESCRIPTION
+        assert pending["amount"] == 15.5
+
+    @pytest.mark.asyncio
+    async def test_skip_description_moves_to_confirm(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        query = make_query("expense:skip_desc")
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace(chat_data={"pending_expense": {"category": "toner", "amount": 15.5}})
+
+        result = await handlers.expense_skip_description(update, context)
+
+        assert result == EXPENSE_CONFIRM
+        assert context.chat_data["pending_expense"]["description"] is None
+        query.message.edit_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_receive_description_moves_to_confirm(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        pending = {"category": "toner", "amount": 15.5}
+        update, context, message = make_text_update("cartridge", chat_data={"pending_expense": pending})
+
+        result = await handlers.expense_receive_description(update, context)
+
+        assert result == EXPENSE_CONFIRM
+        assert pending["description"] == "cartridge"
+
+    @pytest.mark.asyncio
+    async def test_confirm_submits_once_and_ends(self):
+        fake_client = FakeAPIClient(response=(201, {"success": True}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        query = make_query("expense:confirm")
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace(
+            chat_data={"pending_expense": {"category": "toner", "amount": 15.5, "description": "cartridge"}}
+        )
+
+        result = await handlers.expense_confirm(update, context)
+
+        assert result == ConversationHandler.END
+        assert fake_client.calls == [("create_expense", (123, "toner", 15.5, "cartridge"), {})]
+        assert "pending_expense" not in context.chat_data
+        query.message.edit_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cancel_never_calls_backend(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        query = make_query("expense:cancel")
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace(chat_data={"pending_expense": {"category": "toner", "amount": 15.5}})
+
+        result = await handlers.expense_cancel(update, context)
+
+        assert result == ConversationHandler.END
+        assert fake_client.calls == []
+        assert "pending_expense" not in context.chat_data
+        query.message.edit_text.assert_awaited_once()
+
+
+USERS = [
+    {"username": "alice_p", "name": "Alice", "surname": "Perez", "balance": 5.0},
+    {"username": "bruno_g", "name": "Bruno", "surname": "Gomez", "balance": 10.0},
+]
+
+MANY_USERS = [
+    {"username": f"user{i}", "name": f"Name{i}", "surname": f"Surname{i}", "balance": 0.0}
+    for i in range(60)
+]
+
+
+class TestRechargeFlow:
+    @pytest.mark.asyncio
+    async def test_entry_fallback_args_applies_immediately(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_command_update(args=["alice_p", "10"])
+
+        result = await handlers.recharge_entry(update, context)
+
+        assert result == ConversationHandler.END
+        assert fake_client.calls == [("recharge_user", (123, "alice_p", 10.0), {})]
+        message.reply_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_entry_no_args_lists_users_and_enters_search(self):
+        fake_client = FakeAPIClient(response=(200, USERS))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_command_update(args=[])
+
+        result = await handlers.recharge_entry(update, context)
+
+        assert result == RECHARGE_SEARCH
+        assert context.chat_data["recharge_all_users"] == USERS
+        # Small list (<= threshold) — shows tappable buttons immediately.
+        _, kwargs = message.reply_text.call_args
+        assert "reply_markup" in kwargs
+
+    @pytest.mark.asyncio
+    async def test_entry_with_many_users_asks_to_search_first_no_buttons(self):
+        fake_client = FakeAPIClient(response=(200, MANY_USERS))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_command_update(args=[])
+
+        result = await handlers.recharge_entry(update, context)
+
+        assert result == RECHARGE_SEARCH
+        assert context.chat_data["recharge_all_users"] == MANY_USERS
+        # Too many to browse — no button list, just a prompt to type a search.
+        args, kwargs = message.reply_text.call_args
+        assert "reply_markup" not in kwargs
+        assert "60 users" in args[0]
+
+    @pytest.mark.asyncio
+    async def test_search_query_too_short_reprompts_without_filtering(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_text_update("a", chat_data={"recharge_all_users": MANY_USERS})
+
+        result = await handlers.recharge_search(update, context)
+
+        assert result == RECHARGE_SEARCH
+        message.reply_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_search_too_many_matches_asks_to_narrow_no_buttons(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_text_update("name", chat_data={"recharge_all_users": MANY_USERS})
+
+        result = await handlers.recharge_search(update, context)
+
+        assert result == RECHARGE_SEARCH
+        args, kwargs = message.reply_text.call_args
+        assert "reply_markup" not in kwargs
+        assert "narrow" in args[0]
+
+    @pytest.mark.asyncio
+    async def test_search_narrowed_to_few_matches_shows_buttons(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        # 60 unrelated users + 3 sharing a distinctive substring in their name.
+        pool = MANY_USERS + [
+            {"username": f"zzz{i}", "name": "Zelda", "surname": f"Q{i}", "balance": 0.0} for i in range(3)
+        ]
+        update, context, message = make_text_update("zelda", chat_data={"recharge_all_users": pool})
+
+        result = await handlers.recharge_search(update, context)
+
+        assert result == RECHARGE_SEARCH
+        args, kwargs = message.reply_text.call_args
+        assert "reply_markup" in kwargs
+        message.reply_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_entry_forbidden_ends_conversation(self):
+        fake_client = FakeAPIClient(response=(403, {"detail": "nope"}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_command_update(args=[])
+
+        result = await handlers.recharge_entry(update, context)
+
+        assert result == ConversationHandler.END
+
+    @pytest.mark.asyncio
+    async def test_search_no_match_reprompts(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_text_update("zzz", chat_data={"recharge_all_users": USERS})
+
+        result = await handlers.recharge_search(update, context)
+
+        assert result == RECHARGE_SEARCH
+
+    @pytest.mark.asyncio
+    async def test_search_single_match_moves_to_amount(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_text_update("alice", chat_data={"recharge_all_users": USERS})
+
+        result = await handlers.recharge_search(update, context)
+
+        assert result == RECHARGE_AWAIT_AMOUNT
+        assert context.chat_data["recharge_target"]["username"] == "alice_p"
+
+    @pytest.mark.asyncio
+    async def test_search_multiple_matches_shows_picker(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_text_update("_", chat_data={"recharge_all_users": USERS})
+
+        result = await handlers.recharge_search(update, context)
+
+        assert result == RECHARGE_SEARCH
+        message.reply_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_choose_user_moves_to_amount(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        query = make_query("recharge:user:alice_p")
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace(chat_data={"recharge_all_users": USERS})
+
+        result = await handlers.recharge_choose_user(update, context)
+
+        assert result == RECHARGE_AWAIT_AMOUNT
+        assert context.chat_data["recharge_target"]["username"] == "alice_p"
+        query.message.edit_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_receive_amount_applies_and_ends(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_text_update(
+            "10", chat_data={"recharge_target": USERS[0], "recharge_all_users": USERS}
+        )
+
+        result = await handlers.recharge_receive_amount(update, context)
+
+        assert result == ConversationHandler.END
+        assert fake_client.calls == [("recharge_user", (123, "alice_p", 10.0), {})]
+        assert "recharge_target" not in context.chat_data
+
+    @pytest.mark.asyncio
+    async def test_receive_amount_invalid_reprompts(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_text_update("not-a-number", chat_data={"recharge_target": USERS[0]})
+
+        result = await handlers.recharge_receive_amount(update, context)
+
+        assert result == RECHARGE_AWAIT_AMOUNT
+        assert context.chat_data["recharge_target"] == USERS[0]
+
+    @pytest.mark.asyncio
+    async def test_cancel_clears_state(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        query = make_query("recharge:cancel")
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace(chat_data={"recharge_target": {}, "recharge_all_users": []})
+
+        result = await handlers.recharge_cancel(update, context)
+
+        assert result == ConversationHandler.END
+        assert context.chat_data == {}
+
+
+class TestAdjustFlow:
+    @pytest.mark.asyncio
+    async def test_entry_fallback_args_applies_immediately(self):
+        fake_client = FakeAPIClient(response=(200, {"name": "Alice", "balance": 0.0}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_command_update(args=["alice_p", "0"])
+
+        result = await handlers.adjust_entry(update, context)
+
+        assert result == ConversationHandler.END
+        assert fake_client.calls == [("adjust_balance", (123, "alice_p", 0.0), {})]
+        message.reply_text.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_entry_no_args_lists_users_and_enters_search(self):
+        fake_client = FakeAPIClient(response=(200, USERS))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_command_update(args=[])
+
+        result = await handlers.adjust_entry(update, context)
+
+        assert result == ADJUST_SEARCH
+        assert context.chat_data["adjust_all_users"] == USERS
+
+    @pytest.mark.asyncio
+    async def test_search_single_match_moves_to_amount(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_text_update("bruno", chat_data={"adjust_all_users": USERS})
+
+        result = await handlers.adjust_search(update, context)
+
+        assert result == ADJUST_AWAIT_AMOUNT
+        assert context.chat_data["adjust_target"]["username"] == "bruno_g"
+
+    @pytest.mark.asyncio
+    async def test_choose_user_moves_to_amount(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        query = make_query("adjust:user:bruno_g")
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace(chat_data={"adjust_all_users": USERS})
+
+        result = await handlers.adjust_choose_user(update, context)
+
+        assert result == ADJUST_AWAIT_AMOUNT
+        assert context.chat_data["adjust_target"]["username"] == "bruno_g"
+
+    @pytest.mark.asyncio
+    async def test_receive_amount_applies_and_ends(self):
+        fake_client = FakeAPIClient(response=(200, {"name": "Bruno", "balance": 0.0}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_text_update(
+            "0", chat_data={"adjust_target": USERS[1], "adjust_all_users": USERS}
+        )
+
+        result = await handlers.adjust_receive_amount(update, context)
+
+        assert result == ConversationHandler.END
+        assert fake_client.calls == [("adjust_balance", (123, "bruno_g", 0.0), {})]
+        assert "adjust_target" not in context.chat_data
+
+    @pytest.mark.asyncio
+    async def test_receive_amount_negative_reprompts(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_text_update("-5", chat_data={"adjust_target": USERS[1]})
+
+        result = await handlers.adjust_receive_amount(update, context)
+
+        assert result == ADJUST_AWAIT_AMOUNT
+
+    @pytest.mark.asyncio
+    async def test_cancel_clears_state(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        query = make_query("adjust:cancel")
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace(chat_data={"adjust_target": {}, "adjust_all_users": []})
+
+        result = await handlers.adjust_cancel(update, context)
+
+        assert result == ConversationHandler.END
+        assert context.chat_data == {}
+
+
+class TestCancelCommand:
+    @pytest.mark.asyncio
+    async def test_clears_all_flow_state(self):
+        fake_client = FakeAPIClient(response=(200, {}))
+        handlers = BotHandlers(services={"user": UserService(fake_client)})
+        update, context, message = make_command_update(args=[])
+        context.chat_data.update({
+            "stock_target": {}, "stock_items": {}, "stock_delta": 5.0,
+            "pending_expense": {}, "recharge_target": {}, "recharge_all_users": [],
+            "adjust_target": {}, "adjust_all_users": [],
+        })
+
+        result = await handlers.cancel_command(update, context)
+
+        assert result == ConversationHandler.END
+        assert context.chat_data == {}
+        message.reply_text.assert_awaited_once()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.services import UserService
+from src.services import UserService, validate_expense_input
 
 pytestmark = pytest.mark.asyncio
 
@@ -66,3 +66,73 @@ class TestRequestRecharge:
         assert status == 200
         assert len(fake_client.calls) == 1
         assert fake_client.calls[0][0] == "create_recharge_request"
+
+
+class TestAdjustStock:
+    async def test_rejects_non_numeric_delta(self, fake_client):
+        service = UserService(fake_client)
+        status, res = await service.adjust_stock(1, "A4 Paper", "not-a-number")
+        assert status == 400
+        assert fake_client.calls == []
+
+    async def test_rejects_zero_delta(self, fake_client):
+        service = UserService(fake_client)
+        status, res = await service.adjust_stock(1, "A4 Paper", "0")
+        assert status == 400
+        assert fake_client.calls == []
+
+    async def test_accepts_negative_delta(self, fake_client):
+        service = UserService(fake_client)
+        status, res = await service.adjust_stock(1, "A4 Paper", "-50")
+        assert status == 200
+        assert fake_client.calls == [("adjust_stock", (1, "A4 Paper", -50.0), {})]
+
+    async def test_accepts_positive_delta(self, fake_client):
+        service = UserService(fake_client)
+        status, res = await service.adjust_stock(1, "A4 Paper", "20")
+        assert status == 200
+        assert fake_client.calls == [("adjust_stock", (1, "A4 Paper", 20.0), {})]
+
+
+class TestValidateExpenseInput:
+    async def test_rejects_unknown_category(self):
+        ok, category, amount, error = validate_expense_input("snacks", "10")
+        assert ok is False
+        assert "Category must be one of" in error
+
+    async def test_rejects_non_numeric_amount(self):
+        ok, category, amount, error = validate_expense_input("toner", "not-a-number")
+        assert ok is False
+        assert error == "Amount must be a number"
+
+    async def test_rejects_non_positive_amount(self):
+        ok, category, amount, error = validate_expense_input("toner", "0")
+        assert ok is False
+        assert error == "Amount must be positive"
+
+    async def test_normalizes_category_case(self):
+        ok, category, amount, error = validate_expense_input("  TONER ", "15.5")
+        assert ok is True
+        assert category == "toner"
+        assert amount == 15.5
+        assert error is None
+
+
+class TestCreateExpense:
+    async def test_rejects_invalid_category(self, fake_client):
+        service = UserService(fake_client)
+        status, res = await service.create_expense(1, "snacks", "10")
+        assert status == 400
+        assert fake_client.calls == []
+
+    async def test_rejects_non_positive_amount(self, fake_client):
+        service = UserService(fake_client)
+        status, res = await service.create_expense(1, "toner", "0")
+        assert status == 400
+        assert fake_client.calls == []
+
+    async def test_accepts_valid_input(self, fake_client):
+        service = UserService(fake_client)
+        status, res = await service.create_expense(1, "Toner", "15.5", "cartridge")
+        assert status == 200
+        assert fake_client.calls == [("create_expense", (1, "toner", 15.5, "cartridge"), {})]


### PR DESCRIPTION
## Summary
Replaces raw-argument-only commands with guided, button-driven `ConversationHandler` flows:

- `/stock` — pick an item from a list, adjust via a +/- stepper with explicit Confirm/Cancel
- `/expense` — pick a category, enter amount and optional description, then a mandatory confirmation summary before submitting (an expense is a permanent ledger entry)
- `/recharge` / `/adjust` — search-and-pick a user instead of typing a username, gated by a small-result-count threshold so it stays usable with 60+ users (falls back to a text-only "narrow your search" prompt above the threshold)

Raw one-shot command args (`/stock -50 A4 Paper`, `/expense toner 15 note`) remain as a fallback for all four commands.

Depends on the backend's `feature/financial-overhaul` PR (PrintBuddy/print-buddy#39) for the new `/telegram/inventory`, `/telegram/stock-adjust`, and `/telegram/expenses` routes.

## Test plan
- [x] `pytest` — 73/73 passing
- [x] Manually verified all four flows end-to-end against the local-testing stack with a real Telegram account (`@printbudtest_bot`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ros9b1NttjHYjsXncT4Rh